### PR TITLE
Fix `rotation_matrix()` for axis 2 and docs for axes 1 and 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+- Fix the orientation of `rotation_matrix(phi,2)` for a rotation matrix around axis 2. Also fix the docs for `rotation_matrix(phi,1)` and `rotation_matrix(phi,3)`.
+
 ## [2.1.0] - 2023-09-25
 
 ### Added

--- a/docs/api/functions/rotation.md
+++ b/docs/api/functions/rotation.md
@@ -20,7 +20,7 @@ There are 3 possible cases:
 ### `rotation_matrix(phi,3)`
 $$
 \begin{equation}
-  \mathbf{R} = \begin{bmatrix} \cos \varphi & \sin \varphi & 0 \\ -\sin \varphi & \cos \varphi & 0 \\ 0 & 0 & 1 \end{bmatrix}
+  \mathbf{R} = \begin{bmatrix} \cos \varphi & -\sin \varphi & 0 \\ \sin \varphi & \cos \varphi & 0 \\ 0 & 0 & 1 \end{bmatrix}
 \end{equation}
 $$
 
@@ -34,7 +34,7 @@ $$
 ### `rotation_matrix(phi,1)`
 $$
 \begin{equation}
-  \mathbf{R} = \begin{bmatrix} 1 & 0 & 0 \\ 0 &\cos \varphi & \sin \varphi\\ 0 & -\sin \varphi & \cos \varphi\\ \end{bmatrix}
+  \mathbf{R} = \begin{bmatrix} 1 & 0 & 0 \\ 0 &\cos \varphi & -\sin \varphi\\ 0 & \sin \varphi & \cos \varphi\\ \end{bmatrix}
 \end{equation}
 $$
 

--- a/ttb/librotation.f
+++ b/ttb/librotation.f
@@ -18,8 +18,8 @@
         else !i == 2
          rotation_2%ab(1,1) = R(1,1)
          rotation_2%ab(3,3) = R(2,2)
-         rotation_2%ab(1,3) = R(1,2)
-         rotation_2%ab(3,1) = R(2,1)
+         rotation_2%ab(1,3) = R(2,1)
+         rotation_2%ab(3,1) = R(1,2)
         end if
         
        end function rotation_2


### PR DESCRIPTION
closes #56 

by changing the sign of the rotation angle for a rotation around axis 2. Also fixes the docs for rotations around axes 1 and 3 😊.

Now according to https://en.wikipedia.org/wiki/Rotation_matrix.